### PR TITLE
Add home route

### DIFF
--- a/.env
+++ b/.env
@@ -26,7 +26,7 @@ APP_SECRET=
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data_%kernel.environment%.db"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
-DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/playlist?serverVersion=16&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/messenger ###

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,12 +4,12 @@ services:
   database:
     image: postgres:${POSTGRES_VERSION:-16}-alpine
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-app}
+      POSTGRES_DB: ${POSTGRES_DB:-playlist}
       # You should definitely change the password in production
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-!ChangeMe!}
       POSTGRES_USER: ${POSTGRES_USER:-app}
     healthcheck:
-      test: ["CMD", "pg_isready", "-d", "${POSTGRES_DB:-app}", "-U", "${POSTGRES_USER:-app}"]
+      test: ["CMD", "pg_isready", "-d", "${POSTGRES_DB:-playlist}", "-U", "${POSTGRES_USER:-app}"]
       timeout: 5s
       retries: 5
       start_period: 60s

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,17 +1,24 @@
 security:
-    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
     password_hashers:
-        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
-    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
+        App\Entity\User:
+            algorithm: auto
     providers:
-        users_in_memory: { memory: null }
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
+            form_login:
+                login_path: app_login
+                check_path: app_login
+            logout:
+                path: app_logout
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall
@@ -22,8 +29,8 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/login, roles: PUBLIC_ACCESS }
+        - { path: ^/playlist, roles: ROLE_USER }
 
 when@test:
     security:

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class HomeController extends AbstractController
+{
+    #[Route('/', name: 'app_home')]
+    public function index(): RedirectResponse
+    {
+        if ($this->getUser()) {
+            return $this->redirectToRoute('playlist_index');
+        }
+
+        return $this->redirectToRoute('app_login');
+    }
+}

--- a/src/Controller/PlaylistController.php
+++ b/src/Controller/PlaylistController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Playlist;
+use App\Form\PlaylistType;
+use App\Repository\PlaylistRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/playlist')]
+class PlaylistController extends AbstractController
+{
+    #[Route('/', name: 'playlist_index')]
+    #[IsGranted('ROLE_USER')]
+    public function index(PlaylistRepository $playlistRepository): Response
+    {
+        if ($this->isGranted('ROLE_ADMIN')) {
+            $playlists = $playlistRepository->findAll();
+        } else {
+            $playlists = $playlistRepository->findBy(['user' => $this->getUser()]);
+        }
+
+        return $this->render('playlist/index.html.twig', [
+            'playlists' => $playlists,
+        ]);
+    }
+
+    #[Route('/new', name: 'playlist_new')]
+    #[IsGranted('ROLE_USER')]
+    public function new(Request $request, EntityManagerInterface $em): Response
+    {
+        $playlist = new Playlist();
+        $form = $this->createForm(PlaylistType::class, $playlist);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $playlist->setUser($this->getUser());
+            $em->persist($playlist);
+            $em->flush();
+
+            return $this->redirectToRoute('playlist_index');
+        }
+
+        return $this->render('playlist/new.html.twig', [
+            'form' => $form,
+        ]);
+    }
+}
+

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+
+class SecurityController extends AbstractController
+{
+    #[Route('/login', name: 'app_login')]
+    public function login(AuthenticationUtils $authenticationUtils): Response
+    {
+        $error = $authenticationUtils->getLastAuthenticationError();
+        $lastUsername = $authenticationUtils->getLastUsername();
+
+        return $this->render('security/login.html.twig', [
+            'last_username' => $lastUsername,
+            'error' => $error,
+        ]);
+    }
+
+    #[Route('/logout', name: 'app_logout')]
+    public function logout(): void
+    {
+        // Symfony handles logout automatically
+    }
+}
+

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\MediaRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: MediaRepository::class)]
+class Media
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $titre;
+
+    #[ORM\ManyToOne(inversedBy: 'medias')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne(inversedBy: 'medias')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Playlist $playlist = null;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $dateAjout;
+
+    public function __construct()
+    {
+        $this->dateAjout = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitre(): string
+    {
+        return $this->titre;
+    }
+
+    public function setTitre(string $titre): self
+    {
+        $this->titre = $titre;
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getPlaylist(): ?Playlist
+    {
+        return $this->playlist;
+    }
+
+    public function setPlaylist(?Playlist $playlist): self
+    {
+        $this->playlist = $playlist;
+        return $this;
+    }
+
+    public function getDateAjout(): \DateTimeImmutable
+    {
+        return $this->dateAjout;
+    }
+
+    public function setDateAjout(\DateTimeImmutable $dateAjout): self
+    {
+        $this->dateAjout = $dateAjout;
+        return $this;
+    }
+}
+

--- a/src/Entity/Playlist.php
+++ b/src/Entity/Playlist.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PlaylistRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: PlaylistRepository::class)]
+class Playlist
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $titre;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $dateAjout;
+
+    #[ORM\ManyToOne(inversedBy: 'playlists')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\OneToMany(mappedBy: 'playlist', targetEntity: Media::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $medias;
+
+    public function __construct()
+    {
+        $this->dateAjout = new \DateTimeImmutable();
+        $this->medias = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitre(): string
+    {
+        return $this->titre;
+    }
+
+    public function setTitre(string $titre): self
+    {
+        $this->titre = $titre;
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getDateAjout(): \DateTimeImmutable
+    {
+        return $this->dateAjout;
+    }
+
+    public function setDateAjout(\DateTimeImmutable $dateAjout): self
+    {
+        $this->dateAjout = $dateAjout;
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Media>
+     */
+    public function getMedias(): Collection
+    {
+        return $this->medias;
+    }
+
+    public function addMedia(Media $media): self
+    {
+        if (!$this->medias->contains($media)) {
+            $this->medias[] = $media;
+            $media->setPlaylist($this);
+        }
+
+        return $this;
+    }
+
+    public function removeMedia(Media $media): self
+    {
+        if ($this->medias->removeElement($media)) {
+            if ($media->getPlaylist() === $this) {
+                $media->setPlaylist(null);
+            }
+        }
+
+        return $this;
+    }
+}
+

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\UserRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+class User implements UserInterface, PasswordAuthenticatedUserInterface
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 180, unique: true)]
+    private string $email;
+
+    #[ORM\Column(type: 'json')]
+    private array $roles = [];
+
+    #[ORM\Column]
+    private string $password;
+
+    #[ORM\Column(length: 255)]
+    private string $nom;
+
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Playlist::class, orphanRemoval: true)]
+    private Collection $playlists;
+
+    public function __construct()
+    {
+        $this->playlists = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->email;
+    }
+
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        if (empty($roles)) {
+            $roles[] = 'ROLE_USER';
+        }
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+        return $this;
+    }
+
+    public function getNom(): string
+    {
+        return $this->nom;
+    }
+
+    public function setNom(string $nom): self
+    {
+        $this->nom = $nom;
+        return $this;
+    }
+
+    public function eraseCredentials(): void
+    {
+        // If we store any temporary data on the user, clear it here
+    }
+
+    /**
+     * @return Collection<int, Playlist>
+     */
+    public function getPlaylists(): Collection
+    {
+        return $this->playlists;
+    }
+
+    public function addPlaylist(Playlist $playlist): self
+    {
+        if (!$this->playlists->contains($playlist)) {
+            $this->playlists[] = $playlist;
+            $playlist->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removePlaylist(Playlist $playlist): self
+    {
+        if ($this->playlists->removeElement($playlist)) {
+            if ($playlist->getUser() === $this) {
+                $playlist->setUser(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/Form/PlaylistType.php
+++ b/src/Form/PlaylistType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Playlist;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PlaylistType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('titre', TextType::class)
+            ->add('description', TextareaType::class, [
+                'required' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Playlist::class,
+        ]);
+    }
+}
+

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Media;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Media>
+ */
+class MediaRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Media::class);
+    }
+}
+

--- a/src/Repository/PlaylistRepository.php
+++ b/src/Repository/PlaylistRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Playlist;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Playlist>
+ */
+class PlaylistRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Playlist::class);
+    }
+}
+

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<User>
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+}
+

--- a/templates/playlist/index.html.twig
+++ b/templates/playlist/index.html.twig
@@ -1,0 +1,16 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Mes Playlists{% endblock %}
+
+{% block body %}
+<h1>Playlists</h1>
+<ul>
+{% for playlist in playlists %}
+    <li>{{ playlist.titre }} - {{ playlist.description }}</li>
+{% else %}
+    <li>Aucune playlist</li>
+{% endfor %}
+</ul>
+<a href="{{ path('playlist_new') }}">Nouvelle playlist</a>
+{% endblock %}
+

--- a/templates/playlist/new.html.twig
+++ b/templates/playlist/new.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Nouvelle playlist{% endblock %}
+
+{% block body %}
+<h1>Nouvelle playlist</h1>
+{{ form_start(form) }}
+    {{ form_widget(form) }}
+    <button type="submit">Enregistrer</button>
+{{ form_end(form) }}
+{% endblock %}
+

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -1,0 +1,20 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Connexion{% endblock %}
+
+{% block body %}
+<form method="post" action="{{ path('app_login') }}">
+    <label for="email">Email</label>
+    <input type="text" id="email" name="_username" value="{{ last_username }}" required />
+
+    <label for="password">Password</label>
+    <input type="password" id="password" name="_password" required />
+
+    <button type="submit">Se connecter</button>
+
+    {% if error %}
+        <div>{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+    {% endif %}
+</form>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- route `/` now redirects to login or playlist index
- use `playlist` Postgres DB
- restrict playlist pages to authenticated users
- implement login and playlist CRUD basics

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685625edee1c832395bcade309170ab4